### PR TITLE
Fixed quest id for Highland Drake: Thorned Jaw

### DIFF
--- a/Source/db/HighlandDrake.lua
+++ b/Source/db/HighlandDrake.lua
@@ -154,7 +154,7 @@ local manuscripts = {
     {
         name = "Highland Drake: Thorned Jaw",
         itemID = 197115,
-        questID = 69324,
+        questID = 69316,
         source = sources.Rare,
         rareName = L["Shade of Grief"],
     },


### PR DESCRIPTION
Seems like quest id for Highland Drake: Thorned Jaw is incorrect: it duplicates with Highland Drake: Thorn Horns. The correct one should be 69316 (from similar addon, but please check).

P.S. Thanks for the great addon)