### PR TITLE
Winding Slitherdrake: Finned Cheek is not sold in current event

### DIFF
--- a/Source/db/10-1.lua
+++ b/Source/db/10-1.lua
@@ -248,8 +248,7 @@ local manuscripts = {
         name = "Winding Slitherdrake: Finned Cheek",
         itemID = 203319,
         questID = 73807,
-        source = sources.Vendor,
-        vendorName = L["Maztha"],
+        source = sources.Unknown,
         zoneID = 13862,
     },
     {


### PR DESCRIPTION
Currently Winding Slitherdrake: Finned Cheek is not offered by Maztha in Eastern Kingdoms Cup event.