### PR TITLE
db: Complete entry for Pepe costume from Plunderstorm

### DIFF
--- a/Source/db/Pepe.lua
+++ b/Source/db/Pepe.lua
@@ -127,7 +127,10 @@ addon.PepeDB = {
 	},
    	{
 		itemID = 216907,
+		questID = 80093,
 		name = "A Tiny Plumed Tricorne",
-        source = sources.WorldEvent, -- Plunderstorm, cannot find a quest ID for this one
+		source = sources.Renown,
+		renownFaction = 2593,
+		renownRank = 24,
 	},
 }


### PR DESCRIPTION
Originally the collectible was awarded by reaching rank 24 with Keg Leg's Crew introduced in patch 10.2.6 "Plunderstorm" in 2024. In 2025 and 11.0.7 the item could be bought from the event vendor.

The quest ID remains the same regardless of the source.