### PR TITLE
TameTomes: Fix Ottuk Taming

### DIFF
--- a/Source/TameTomesTab.lua
+++ b/Source/TameTomesTab.lua
@@ -29,7 +29,9 @@ function TameTomesMixin:GetEntryDB()
 end
 
 function TameTomesMixin:IsCollected(data)
-    if data.questID then
+    if data.accountQuestID then
+        return C_QuestLog.IsQuestFlaggedCompletedOnAccount(data.accountQuestID)
+    elseif data.questID then
         return C_QuestLog.IsQuestFlaggedCompleted(data.questID)
     else
         return IsPlayerSpell(data.spellID)

--- a/Source/db/TameTomes.lua
+++ b/Source/db/TameTomes.lua
@@ -63,7 +63,7 @@ addon.TameTomesDB = {
 	},
     {
 		spellID = 390631,
-        questID = 66444,
+        accountQuestID = 66444,
 		name = "Ottuk Taming",
         source = sources.Quest,
         sourceQuestID = 66444,


### PR DESCRIPTION
Ottuk Taming is unlocked account-wide from a quest but the quest itself is not account-wide, so alts that haven't done that quest chain would show it as not unlocked even when it has been unlocked.